### PR TITLE
92 Uzależnienie animacji od czasu

### DIFF
--- a/src/Map/Dungeon.cpp
+++ b/src/Map/Dungeon.cpp
@@ -120,17 +120,11 @@ void Dungeon::render(sf::RenderWindow& window)
 
 void Dungeon::addPlayerComponents(const Entity player)
 {
-    gCoordinator.addComponents(player,
-        TileComponent{configSingleton.GetConfig().playerAnimation, "Characters", 5},
-        RenderComponent{},
-        TransformComponent{GameUtility::startingPosition},
-        AnimationComponent{},
-        CharacterComponent{.hp = configSingleton.GetConfig().defaultCharacterHP},
-        PlayerComponent{},
-        ColliderComponent{},
-        InventoryComponent{},
-        EquipmentComponent{},
-        FloorComponent{},
+    gCoordinator.addComponents(
+        player, TileComponent{configSingleton.GetConfig().playerAnimation, "Characters", 5}, RenderComponent{},
+        TransformComponent{GameUtility::startingPosition}, AnimationComponent{},
+        CharacterComponent{.hp = configSingleton.GetConfig().defaultCharacterHP}, PlayerComponent{},
+        ColliderComponent{}, InventoryComponent{}, EquipmentComponent{}, FloorComponent{},
         TravellingDungeonComponent{.moveCallback = [this](const glm::ivec2& dir) { moveInDungeon(dir); }},
         PassageComponent{.moveCallback = [this] { moveDownDungeon(); }});
 }
@@ -140,16 +134,14 @@ void Dungeon::createRemotePlayer(const uint32_t id)
     const auto tag = std::format("Player {}", id);
     m_entities[id] = gCoordinator.createEntity();
 
-    gCoordinator.addComponents(m_entities[id],
+    gCoordinator.addComponents(
+        m_entities[id],
         TransformComponent(sf::Vector2f(getSpawnOffset(configSingleton.GetConfig().startingPosition.x, id),
                                         getSpawnOffset(configSingleton.GetConfig().startingPosition.y, id)),
                            0.f, sf::Vector2f(1.f, 1.f), {0.f, 0.f}),
-        TileComponent{configSingleton.GetConfig().playerAnimation, "Characters", 3},
-        RenderComponent{},
-        AnimationComponent{},
-        CharacterComponent{.hp = configSingleton.GetConfig().defaultCharacterHP},
-        MultiplayerComponent{},
-        ColliderComponent{});
+        TileComponent{configSingleton.GetConfig().playerAnimation, "Characters", 3}, RenderComponent{},
+        AnimationComponent{}, CharacterComponent{.hp = configSingleton.GetConfig().defaultCharacterHP},
+        MultiplayerComponent{}, ColliderComponent{});
 
     Collision cc = gCoordinator.getRegisterSystem<TextureSystem>()->getCollision(
         "Characters", configSingleton.GetConfig().playerAnimation);
@@ -245,17 +237,17 @@ void Dungeon::setupHelmetEntity(const Entity player) const
 
 void Dungeon::update(const float deltaTime)
 {
-    m_itemSystem->update();
+    m_itemSystem->update(deltaTime);
     m_playerMovementSystem->update(deltaTime);
     m_weaponSystem->update(deltaTime);
     m_animationSystem->update(deltaTime);
     m_roomListenerSystem->update(deltaTime);
     m_itemSpawnerSystem->updateAnimation(deltaTime);
-    m_enemySystem->update();
+    m_enemySystem->update(deltaTime);
+    m_textTagSystem->update(deltaTime);
+    m_characterSystem->update(deltaTime);
     m_travellingSystem->update();
     m_passageSystem->update();
-    m_characterSystem->update();
-    m_textTagSystem->update(deltaTime);
 
     if (m_multiplayerSystem->isConnected())
     {

--- a/src/MenuStateMachine/GameState.cpp
+++ b/src/MenuStateMachine/GameState.cpp
@@ -7,20 +7,17 @@
 #include "ObjectCreatorSystem.h"
 
 extern Coordinator gCoordinator;
+extern PublicConfigSingleton configSingleton;
 
 void GameState::init()
 {
     m_dungeon.m_stateChangeCallback = m_stateChangeCallback;
+    m_collisionSystem = gCoordinator.getRegisterSystem<CollisionSystem>().get();
+    m_oneFrameTime = configSingleton.GetConfig().oneFrameTime;
     m_dungeon.init();
 }
 
-void GameState::handleCollision(const float deltaTime)
-{
-    const auto collisionSystem = gCoordinator.getRegisterSystem<CollisionSystem>();
-    constexpr auto timeStep = 1.f / 60.f;
-    collisionSystem->update(deltaTime);
-    collisionSystem->updateSimulation(timeStep, 8, 3);
-}
+void GameState::handleCollision(const float deltaTime) { m_collisionSystem->update(deltaTime, m_oneFrameTime, 8, 3); }
 
 void GameState::render(sf::RenderWindow &window)
 {

--- a/src/MenuStateMachine/GameState.h
+++ b/src/MenuStateMachine/GameState.h
@@ -6,9 +6,7 @@
 class GameState : public State
 {
 public:
-    GameState()
-    {
-    };
+    GameState(){};
 
     void update(float deltaTime) override;
     void render(sf::RenderWindow& window) override;
@@ -17,4 +15,6 @@ public:
 private:
     Dungeon m_dungeon{};
     void handleCollision(float deltaTime);
+    CollisionSystem* m_collisionSystem = nullptr;
+    float m_oneFrameTime;
 };

--- a/src/Systems/CharacterSystem.cpp
+++ b/src/Systems/CharacterSystem.cpp
@@ -2,13 +2,22 @@
 #include "CharacterComponent.h"
 #include "ColliderComponent.h"
 #include "Coordinator.h"
+#include "PublicConfigMenager.h"
 
 extern Coordinator gCoordinator;
+extern PublicConfigSingleton configSingleton;
 
-void CharacterSystem::update() const
+void CharacterSystem::update(const float& deltaTime)
 {
-    cleanUpDeadEntities();
+    if (m_frameTime += deltaTime; m_frameTime >= configSingleton.GetConfig().oneFrameTime * 1000)
+    {
+        m_frameTime -= configSingleton.GetConfig().oneFrameTime * 1000;
+        performFixedUpdate();
+    }
 }
+
+void CharacterSystem::performFixedUpdate() { cleanUpDeadEntities(); }
+
 
 void CharacterSystem::cleanUpDeadEntities() const
 {
@@ -22,7 +31,7 @@ void CharacterSystem::cleanUpDeadEntities() const
 
         if (auto* colliderComponent = gCoordinator.tryGetComponent<ColliderComponent>(entity))
         {
-           colliderComponent->toDestroy = true;
+            colliderComponent->toDestroy = true;
         }
         else
         {

--- a/src/Systems/CharacterSystem.h
+++ b/src/Systems/CharacterSystem.h
@@ -5,8 +5,10 @@ class CharacterSystem : public System
 {
 public:
     explicit CharacterSystem() = default;
-    void update() const;
+    void update(const float&);
 
 private:
     void cleanUpDeadEntities() const;
+    void performFixedUpdate();
+    float m_frameTime{};
 };

--- a/src/Systems/CollisionSystem.cpp
+++ b/src/Systems/CollisionSystem.cpp
@@ -98,12 +98,13 @@ void CollisionSystem::createMapCollision()
     }
 }
 
-void CollisionSystem::update(const float& deltaTime)
+void CollisionSystem::update(const float& deltaTime, float timeStep, int32 velocityIterations, int32 positionIterations)
 {
     if (m_frameTime += deltaTime; m_frameTime >= configSingleton.GetConfig().oneFrameTime * 1000)
     {
         m_frameTime -= configSingleton.GetConfig().oneFrameTime * 1000;
         performFixedUpdate();
+        updateSimulation(timeStep, velocityIterations, positionIterations);
     }
 }
 

--- a/src/Systems/CollisionSystem.h
+++ b/src/Systems/CollisionSystem.h
@@ -21,7 +21,7 @@ class CollisionSystem : public System
 {
 public:
     void init();
-    void update(const float&);
+    void update(const float&, float, int, int);
     void createMapCollision();
     void performFixedUpdate() const;
     void updateSimulation(float timeStep, int32 velocityIterations, int32 positionIterations) const;

--- a/src/Systems/EnemySystem.cpp
+++ b/src/Systems/EnemySystem.cpp
@@ -17,7 +17,7 @@ void EnemySystem::init()
     dis = std::uniform_real_distribution<float>(-1, 1); // Range between -1 and 1
 }
 
-void EnemySystem::update()
+void EnemySystem::performFixedUpdate()
 {
     for (const auto entity : m_entities)
         if (gCoordinator.hasComponent<TransformComponent>(entity))
@@ -32,6 +32,15 @@ void EnemySystem::update()
         }
 }
 
+void EnemySystem::update(const float& deltaTime)
+{
+    if (m_frameTime += deltaTime; m_frameTime >= configSingleton.GetConfig().oneFrameTime * 1000)
+    {
+        m_frameTime -= configSingleton.GetConfig().oneFrameTime * 1000;
+        performFixedUpdate();
+    }
+}
+
 void EnemySystem::deleteEnemies() const
 {
     std::vector<Entity> entitiesToKill;
@@ -43,6 +52,5 @@ void EnemySystem::deleteEnemies() const
         else
             entitiesToKill.push_back(entity);
 
-    for (const auto entity : entitiesToKill)
-        gCoordinator.destroyEntity(entity);
+    for (const auto entity : entitiesToKill) gCoordinator.destroyEntity(entity);
 }

--- a/src/Systems/EnemySystem.h
+++ b/src/Systems/EnemySystem.h
@@ -10,11 +10,13 @@ class EnemySystem : public System
 public:
     EnemySystem();
     void init();
-    void update();
+    void performFixedUpdate();
+    void update(const float&);
     void deleteEnemies() const;
 
 private:
     std::random_device rd;
     std::mt19937 gen;
     std::uniform_real_distribution<float> dis;
+    float m_frameTime{};
 };

--- a/src/Systems/InventorySystem.cpp
+++ b/src/Systems/InventorySystem.cpp
@@ -58,6 +58,7 @@ void InventorySystem::pickUpItem(const GameType::PickUpInfo pickUpItemInfo) cons
         gCoordinator.removeComponent<ItemAnimationComponent>(pickUpItemInfo.itemEntity);
 
     gCoordinator.getComponent<ItemComponent>(pickUpItemInfo.itemEntity).equipped = true;
+    gCoordinator.getComponent<RenderComponent>(pickUpItemInfo.itemEntity).color = sf::Color::White;
 
     auto &[equipment] = gCoordinator.getComponent<EquipmentComponent>(pickUpItemInfo.characterEntity);
 

--- a/src/Systems/ItemSystem.cpp
+++ b/src/Systems/ItemSystem.cpp
@@ -81,11 +81,10 @@ void ItemSystem::displayBodyArmourStats(const Entity entity)
     ImGui::PopStyleColor();
 }
 
-
-void ItemSystem::update()
+void ItemSystem::performFixedUpdate()
 {
     const auto &playerTransformComponent = gCoordinator.getComponent<TransformComponent>(config::playerEntity);
-    double minDistance = std::numeric_limits<int>::max();
+    minDistance = std::numeric_limits<int>::max();
     closestItem = {};
 
     for (const auto entity : m_entities)
@@ -122,13 +121,25 @@ void ItemSystem::update()
     }
 
     if (closestItem.itemEntity == 0 || gCoordinator.hasComponent<ChestComponent>(closestItem.itemEntity))
-    {
         closestItem = {};
-        return;
+}
+
+void ItemSystem::update(const float &deltaTime)
+{
+    if (m_frameTime += deltaTime; m_frameTime >= configSingleton.GetConfig().oneFrameTime * 1000)
+    {
+        m_frameTime -= configSingleton.GetConfig().oneFrameTime * 1000;
+        performFixedUpdate();
     }
 
     if (minDistance <= config::weaponInteractionDistance)
     {
+        if (closestItem.itemEntity == 0 || gCoordinator.hasComponent<ChestComponent>(closestItem.itemEntity))
+        {
+            closestItem = {};
+            return;
+        }
+
         gCoordinator.getComponent<RenderComponent>(closestItem.itemEntity).color = sf::Color(255, 102, 102);
 
         switch (closestItem.slot)
@@ -143,7 +154,7 @@ void ItemSystem::update()
             displayBodyArmourStats(closestItem.itemEntity);
             break;
         default:
-            return;
+            break;
         }
     }
     else

--- a/src/Systems/ItemSystem.h
+++ b/src/Systems/ItemSystem.h
@@ -8,7 +8,7 @@ class ItemSystem : public System
 {
 public:
     void init();
-    void update();
+    void update(const float& deltaTime);
     void markClosest();
     void displayWeaponStats(Entity entity);
     void displayHelmetStats(Entity entity);
@@ -18,5 +18,7 @@ public:
 
 private:
     float m_frameTime{};
+    double minDistance = std::numeric_limits<int>::max();
     GameType::PickUpInfo closestItem{};
+    void performFixedUpdate();
 };

--- a/src/Systems/PlayerMovementSystem.cpp
+++ b/src/Systems/PlayerMovementSystem.cpp
@@ -58,16 +58,16 @@ void PlayerMovementSystem::handleMovement()
     glm::vec2 dir{};
 
     if (inputHandler->isHeld(InputType::MoveUp)) // Move Up
-        dir.y -= 1;
+        dir.y = -1;
 
     if (inputHandler->isHeld(InputType::MoveDown)) // Move Down
-        dir.y += 1;
+        dir.y = 1;
 
     if (inputHandler->isHeld(InputType::MoveRight)) // Move Right
-        dir.x += 1;
+        dir.x = 1;
 
     if (inputHandler->isHeld(InputType::MoveLeft)) // Move Left
-        dir.x -= 1;
+        dir.x = -1;
 
     for (const auto entity : m_entities)
     {

--- a/src/Systems/RenderSystem.h
+++ b/src/Systems/RenderSystem.h
@@ -1,12 +1,12 @@
 #pragma once
 
+#include <vector>
 #include "Config.h"
 #include "RenderComponent.h"
 #include "SFML/Graphics/Sprite.hpp"
 #include "SFML/System/Vector2.hpp"
 #include "SFML/Window/Window.hpp"
 #include "System.h"
-#include <vector>
 
 namespace sf
 {
@@ -54,4 +54,5 @@ private:
     std::vector<Entity> players;
     sf::Vector2u windowSize{};
     sf::Vector2f newMapOffset{};
+    float m_frameTime{};
 };


### PR DESCRIPTION
### Uzależnienie animacji od czasu 

- Dodano kolejne rozróżnienia update'ów dla systemów `update(const float&)`, posiadające zegar, który ogranicza wywołania `performFixedUpdate()` (właściwy update) do 60 razy na sekundę (lub inną stałą ustaloną w configu). 
- Dodano podobną mechanikę do kalkulacji silnika fizyki (`CollisionSystem::updateSimulation`), której brak powodował, że gracz mógł poruszać się szybciej niż powinien.

----

### Problemy 

- Dla lepszego efektu chyba trzeba będzie wybrać inną stałą niż 1.f/60.f.